### PR TITLE
Haptics Improvement

### DIFF
--- a/Unofficial SF Symbols Game/Unofficial SF Symbols Game/Views/Main View/MainSymbolGameView.swift
+++ b/Unofficial SF Symbols Game/Unofficial SF Symbols Game/Views/Main View/MainSymbolGameView.swift
@@ -11,6 +11,8 @@ import SwiftUI
 var numberOfOptions: Range<Int> = 0..<4
 
 class MainSymbolGameViewModel: ObservableObject {
+    //propertyForFeedback
+    @State private var response = UINotificationFeedbackGenerator()
     // MARK:- Published Properties
     @Published var symbols = Symbols.symbols.shuffled()
     @Published var correctAnswer = Int.random(in: numberOfOptions)
@@ -23,17 +25,22 @@ class MainSymbolGameViewModel: ObservableObject {
     func askQuestion() {
         symbols.shuffle()
         correctAnswer = Int.random(in: numberOfOptions)
+        //prepare the tapticEngine
+        self.response.prepare()
     }
     
     func symbolTapped(_ number: Int) {
         showingScore.toggle()
         // Calling haptic feedback
-        haptickFeedback.feedback.haptiFeedback()
+//        haptickFeedback.feedback.haptiFeedback()
         if number == correctAnswer {
+            
             scoreTitle = "Correct"
             score += 1
         } else {
             scoreTitle = "Wrong"
+            //call haptic response on error 
+            self.response.notificationOccurred(.error)
         }
     }
 }


### PR DESCRIPTION
Hi, I saw that u recently added haptic feedback in the app and think that it was a good addition to the user experience. 
But, I found some **Problems** with the haptic feedback usage in the app:-
- There is the risk that the haptic will be delayed because the Taptic Engine wasn’t ready. In this case the haptic will still play, but it could be up to maybe half a second late – enough to feel disconnected from the user interface.
- Too much use of haptic feedback could annoy the user or worse, the user might become desensitized to them – they lose all usefulness either as an alert or as a little spark of delight.

# Solutions
In MainSymbolGameView.swift
-  Added a call to prepare the Taptic engine before the haptic feedback is needed which will ensure that their are no delays or confusions. 
- Added hapticFeedback for wrong responses only, so when the failure haptic is played, it feels a little bit more special. 

I'd really appreciate your response for any changes or suggestions. 
